### PR TITLE
fix incrrect module path

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/binance-chain-npm/bsc-web3-connector.git"
   },
   "main": "dist/index.js",
-  "module": "dist/walletconnect-connector.esm.js",
+  "module": "dist/bsc-connector.esm.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/binance-chain-npm/bsc-web3-connector.git"
   },
   "main": "dist/index.js",
-  "module": "dist/web3-connector.esm.js",
+  "module": "dist/walletconnect-connector.esm.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
The current incorrect module path will cause a vitejs compilation error.

```bash
yarn run v1.22.10
$ vite
 > node_modules/vite/dist/node/chunks/dep-1bdbec90.js:34388:14: error: [vite:dep-scan] Failed to resolve entry for package "@binance-chain/bsc-connector". The package may have incorrect main/module/exports specified in its package.json.
    34388 │         throw new Error(`Failed to resolve entry for package "...
          ╵               ^
    at resolvePackageEntry (/Users/koishi/project/web-mimo-v2-dapp/node_modules/vite/dist/node/chunks/dep-1bdbec90.js:34388:15)
    at tryNodeResolve (/Users/koishi/project/web-mimo-v2-dapp/node_modules/vite/dist/node/chunks/dep-1bdbec90.js:34225:11)

   node_modules/vite/dist/node/chunks/dep-1bdbec90.js:46233:18: note: This error came from the "onResolve" callback registered here
    46233 │             build.onResolve({
          ╵                   ~~~~~~~~~
    at setup (/Users/koishi/project/web-mimo-v2-dapp/node_modules/vite/dist/node/chunks/dep-1bdbec90.js:46233:19)
    at handlePlugins (/Users/koishi/project/web-mimo-v2-dapp/node_modules/esbuild/lib/main.js:676:7)
```